### PR TITLE
Changes self-manage MFA policy to allow any named MFA device

### DIFF
--- a/policies.tf
+++ b/policies.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "manage_mfa" {
       "iam:*MFADevice"
     ]
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/${each.key}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/*",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${each.key}"
     ]
     sid = "AllowUserToManageTheirMFA"
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "enforce_mfa" {
       "iam:ChangePassword"
     ]
     not_resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/${each.key}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/*",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${each.key}"
     ]
     sid = "DenyIAMAccessToOtherUsersUnlessMFAd"

--- a/spec/integration/basic_spec.rb
+++ b/spec/integration/basic_spec.rb
@@ -278,7 +278,7 @@ describe 'basic' do
 
         expect(created_user)
           .to(be_allowed_action('iam:*MFADevice')
-                .resource_arn("arn:aws:iam::#{account_id}:mfa/#{user_name}"))
+                .resource_arn("arn:aws:iam::#{account_id}:mfa/*"))
         expect(created_user)
           .to(be_allowed_action('iam:*MFADevice')
                 .resource_arn(created_user.arn))

--- a/spec/unit/policies_spec.rb
+++ b/spec/unit/policies_spec.rb
@@ -166,7 +166,7 @@ describe 'policies' do
                     Effect: 'Allow',
                     Action: 'iam:*MFADevice',
                     Resource: %W[
-                      arn:aws:iam::#{@account_id}:mfa/test@example.com
+                      arn:aws:iam::#{@account_id}:mfa/*
                       arn:aws:iam::#{@account_id}:user/test@example.com
                     ]
                   )
@@ -278,7 +278,7 @@ describe 'policies' do
                     Effect: 'Allow',
                     Action: 'iam:*MFADevice',
                     Resource: %W[
-                      arn:aws:iam::#{@account_id}:mfa/test@example.com
+                      arn:aws:iam::#{@account_id}:mfa/*
                       arn:aws:iam::#{@account_id}:user/test@example.com
                     ]
                   )
@@ -352,7 +352,7 @@ describe 'policies' do
                       iam:ChangePassword
                     ],
                     NotResource: %W[
-                      arn:aws:iam::#{@account_id}:mfa/test@example.com
+                      arn:aws:iam::#{@account_id}:mfa/*
                       arn:aws:iam::#{@account_id}:user/test@example.com
                     ],
                     Condition: {
@@ -431,7 +431,7 @@ describe 'policies' do
                       iam:ChangePassword
                     ],
                     NotResource: %W[
-                      arn:aws:iam::#{@account_id}:mfa/test@example.com
+                      arn:aws:iam::#{@account_id}:mfa/*
                       arn:aws:iam::#{@account_id}:user/test@example.com
                     ],
                     Condition: {
@@ -510,7 +510,7 @@ describe 'policies' do
                           iam:ChangePassword
                         ],
                         NotResource: %W[
-                          arn:aws:iam::#{@account_id}:mfa/test@example.com
+                          arn:aws:iam::#{@account_id}:mfa/*
                           arn:aws:iam::#{@account_id}:user/test@example.com
                         ],
                         Condition: {
@@ -590,7 +590,7 @@ describe 'policies' do
                           iam:ChangePassword
                         ],
                         NotResource: %W[
-                          arn:aws:iam::#{@account_id}:mfa/test@example.com
+                          arn:aws:iam::#{@account_id}:mfa/*
                           arn:aws:iam::#{@account_id}:user/test@example.com
                         ],
                         Condition: {
@@ -829,7 +829,7 @@ describe 'policies' do
                     Effect: 'Allow',
                     Action: 'iam:*MFADevice',
                     Resource: %W[
-                      arn:aws:iam::#{@account_id}:mfa/#{user[:name]}
+                      arn:aws:iam::#{@account_id}:mfa/*
                       arn:aws:iam::#{@account_id}:user/#{user[:name]}
                     ]
                   )
@@ -852,7 +852,7 @@ describe 'policies' do
                         Effect: 'Allow',
                         Action: 'iam:*MFADevice',
                         Resource: %W[
-                          arn:aws:iam::#{@account_id}:mfa/#{user[:name]}
+                          arn:aws:iam::#{@account_id}:mfa/*
                           arn:aws:iam::#{@account_id}:user/#{user[:name]}
                         ]
                       )
@@ -950,7 +950,7 @@ describe 'policies' do
                       iam:ChangePassword
                     ],
                     NotResource: %W[
-                      arn:aws:iam::#{@account_id}:mfa/#{user[:name]}
+                      arn:aws:iam::#{@account_id}:mfa/*
                       arn:aws:iam::#{@account_id}:user/#{user[:name]}
                     ],
                     Condition: {
@@ -983,7 +983,7 @@ describe 'policies' do
                       iam:ChangePassword
                     ],
                     NotResource: %W[
-                      arn:aws:iam::#{@account_id}:mfa/#{user[:name]}
+                      arn:aws:iam::#{@account_id}:mfa/*
                       arn:aws:iam::#{@account_id}:user/#{user[:name]}
                     ],
                     Condition: {


### PR DESCRIPTION
As shown here, AWS have recently changed how MFA devices are configured, whereas you can now have multiple and the user is asked for the name of their MFA device upfront.

![image](https://github.com/infrablocks/terraform-aws-access-control/assets/1202911/646571b7-fd1b-48c4-8410-7b00f449b927)

This poses a problem as currently the policy associated with this in the module assumes that your MFA device will be called the same as your username.

There's further information on this issue here: https://stackoverflow.com/questions/73788181/iam-user-is-not-allowed-to-perform

For the changes, I've simply replaced the name part of the MFA device with a wildcard.

Please do let me know if any questions.

Thanks,
Jordan